### PR TITLE
fix: swim_speed returning low values like 0.07 instead of only 0.0

### DIFF
--- a/src/main/java/cc/unilock/sinytra1343/mixin/LivingEntityMixin.java
+++ b/src/main/java/cc/unilock/sinytra1343/mixin/LivingEntityMixin.java
@@ -11,21 +11,25 @@ import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(LivingEntity.class)
 public class LivingEntityMixin {
-	@ModifyReturnValue(method = "getAttributeValue", at = @At("RETURN"))
-	private double getAttributeValue(double original, Holder<Attribute> attribute) {
-		if (original == 0.0D) {
-			if (attribute.is(NeoForgeMod.SWIM_SPEED::is)) {
-				return 1.0D;
-			}
-			if (attribute.is(NeoForgeMod.NAMETAG_DISTANCE::is)) {
-				return 64.0D;
-			}
-			if (attribute.is(NeoForgeMod.CREATIVE_FLIGHT::is)) {
-				if (((LivingEntity) (Object) this) instanceof Player player && player.isCreative()) {
-					return 1.0D;
-				}
-			}
-		}
-		return original;
-	}
+    @ModifyReturnValue(method = "getAttributeValue", at = @At("RETURN"))
+    private double getAttributeValue(double original, Holder<Attribute> attribute) {
+        if (attribute.is(NeoForgeMod.SWIM_SPEED::is)) {
+            if (original <= 0.1D) {
+                return 1.0D;
+            }
+        }
+        if (attribute.is(NeoForgeMod.NAMETAG_DISTANCE::is)) {
+            if (original <= 0.1D) {
+                return 64.0D;
+            }
+        }
+        if (attribute.is(NeoForgeMod.CREATIVE_FLIGHT::is)) {
+            if (((LivingEntity) (Object) this) instanceof Player player && player.isCreative()) {
+                if (original <= 0.1D) {
+                    return 1.0D;
+                }
+            }
+        }
+        return original;
+    }
 }


### PR DESCRIPTION
Previously, the fix only handled cases where the attribute was exactly 0.0D.
In my case, I encountered a situation where SWIM_SPEED was set to a very low value like 0.07D, probably because I'm using more than just BetterEnd — something else broke the swim speed again.

This update adjusts the fix to correct any value lower than or equal to 0.1D, solving the swimming movement issue.

I have tested it in-game, and it seems to resolve the problem properly so far.

Please feel free to suggest any changes if needed — I'm happy to make any adjustments you think are necessary. Thanks for your work on this project!